### PR TITLE
Handle `poll` option as a private option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-posts-voting",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"type": "module",
 	"description": "Template repository for using TypeScript",
 	"main": "dist/index.js",

--- a/src/components/Voting/Form.vue
+++ b/src/components/Voting/Form.vue
@@ -40,9 +40,9 @@ onUpdate((post) => {
 	const editedPost = {
 		...post,
 		options: [
-			...post.options.filter((option) => option.key !== 'poll'),
+			...post.options.filter((option) => option.key !== '#poll'),
 			{
-				key: 'poll',
+				key: '#poll',
 				value: poll,
 			},
 		],

--- a/src/components/feed-after-post-content.vue
+++ b/src/components/feed-after-post-content.vue
@@ -46,7 +46,7 @@ onMounted(async () => {
 	}
 
 	const pollOption = currentPostInfo.value.options.find(
-		(option: any) => option.key === 'poll',
+		(option: any) => option.key === '#poll',
 	)
 
 	if (!pollOption) {


### PR DESCRIPTION
The content of the `poll` option might be inappropriate for non-members to see.

I have renamed the option key to `#poll` to make the option masking-target.
